### PR TITLE
suggestion: add `{.gdclass.}` prgama to automate `isInheritanceOf` call

### DIFF
--- a/src/godot/helper/classDefiner.nim
+++ b/src/godot/helper/classDefiner.nim
@@ -76,7 +76,6 @@ macro gdClass*(typeDef: untyped): untyped =
     newCall(bindSym"isInheritanceOf", innerTypeName, inheritName),
     innerTypeName
   ))
-  debugEcho result.repr
 
 
 template isInitializedOn*(Class: typedesc[SomeUserClass]; level: InitializationLevel): untyped =


### PR DESCRIPTION
hi there,

This PR implements a `{.gdclass.}` pragma to  safe 1 line of code

So you can do
```nim
type MyNode* {.gdClass.} = ref object of Node
```
instead of
```nim
type MyNode* = ref object of Node
MyNode.isInheritanceOf Node
```

I know it isnt realy important. but 1 line is 1 line.

One drawback however is that this breaks the order-insensitivity of `type` sections. So you cant define mutual recursive types that way. But I dont realy think you would ever have mutual recursive gd types. But even if you have, you can still go back to `isInheritanceOf`